### PR TITLE
Additional error checks for certain errors on exchange

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -76,13 +76,13 @@ function OAuth2Strategy(options, verify) {
     options = undefined;
   }
   options = options || {};
-  
+
   if (!verify) { throw new TypeError('OAuth2Strategy requires a verify callback'); }
   if (!options.authorizationURL) { throw new TypeError('OAuth2Strategy requires a authorizationURL option'); }
   if (!options.tokenURL) { throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
   if (!options.clientID) { throw new TypeError('OAuth2Strategy requires a clientID option'); }
   if (!options.clientSecret) { throw new TypeError('OAuth2Strategy requires a clientSecret option'); }
-  
+
   passport.Strategy.call(this);
   this.name = 'oauth2';
   this._verify = verify;
@@ -118,7 +118,7 @@ util.inherits(OAuth2Strategy, passport.Strategy);
 OAuth2Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req.query && req.query.error) {
     if (req.query.error == 'access_denied') {
       return this.fail({ message: req.query.error_description });
@@ -126,7 +126,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
     }
   }
-  
+
   var callbackURL = options.callbackURL || this._callbackURL;
   if (callbackURL) {
     var parsed = url.parse(callbackURL);
@@ -136,13 +136,13 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy }), callbackURL);
     }
   }
-  
+
   if (req.query && req.query.code) {
     var code = req.query.code;
-    
+
     if (this._state) {
       if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
+
       var key = this._key;
       if (!req.session[key]) {
         return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
@@ -151,17 +151,17 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       if (!state) {
         return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
       }
-      
+
       delete req.session[key].state;
       if (Object.keys(req.session[key]).length === 0) {
         delete req.session[key];
       }
-      
+
       if (state !== req.query.state) {
         return this.fail({ message: 'Invalid authorization request state.' }, 403);
       }
     }
-    
+
     // NOTE: The module oauth (0.9.5), which is a dependency, automatically adds
     //       a 'type=web_server' parameter to the percent-encoded data sent in
     //       the body of the access token request.  This appears to be an
@@ -171,16 +171,28 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     this._oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL },
       function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-        
+
+        // Deal with the case where the provider
+        // a) Returns a 200 status code
+        // b) Does not return accessToken/refreshTokens are null
+        // c) The params contains an error message.
+        //
+        // Currently GitHub OAuth behaves like this for some types of errors, for
+        // example, when the exchange code is invalid (or has been reused)
+        // When this happens, throw an error with the message
+        if(!accessToken && !refreshToken && params.error) {
+          return self.error(self._createOAuthError('Failed to obtain access token. Provider returned: ' + params.error, params.error));
+        }
+
         self._loadUserProfile(accessToken, function(err, profile) {
           if (err) { return self.error(err); }
-          
+
           function verified(err, user, info) {
             if (err) { return self.error(err); }
             if (!user) { return self.fail(info); }
             self.success(user, info);
           }
-          
+
           try {
             if (self._passReqToCallback) {
               var arity = self._verify.length;
@@ -209,7 +221,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     //       This appears to be an artifact from an earlier draft of OAuth 2.0
     //       (draft 22, as of the time of this writing).  This parameter is not
     //       necessary, but its presence does not appear to cause any issues.
-    
+
     var params = this.authorizationParams(options);
     params.response_type = 'code';
     params.redirect_uri = callbackURL;
@@ -223,14 +235,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       params.state = state;
     } else if (this._state) {
       if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
+
       var key = this._key;
       state = uid(24);
       if (!req.session[key]) { req.session[key] = {}; }
       req.session[key].state = state;
       params.state = state;
     }
-    
+
     var location = this._oauth2.getAuthorizeUrl(params);
     this.redirect(location);
   }
@@ -301,14 +313,14 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
  */
 OAuth2Strategy.prototype._loadUserProfile = function(accessToken, done) {
   var self = this;
-  
+
   function loadIt() {
     return self.userProfile(accessToken, done);
   }
   function skipIt() {
     return done(null);
   }
-  
+
   if (typeof this._skipUserProfile == 'function' && this._skipUserProfile.length > 1) {
     // async
     this._skipUserProfile(accessToken, function(err, skip) {


### PR DESCRIPTION
We have experienced some problems with GitHub OAuth during the exchange process where:

The provider:
* Returns a 200 status code
* Does not return accessToken/refreshTokens
* The params contains an error message.

For example, when an invalid or used code is used for token exchange:
`curl -X POST -i https://github.com/login/oauth/access_token -F client_id=xxxx -F client_secret=xxxx -F code=1234567890 -F redirect_uri=xxxx`
(replace, the xxxx's with appropriate values of course)

GitHub will return:
```
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Server: GitHub.com
Date: Fri, 06 Dec 2013 12:30:05 GMT
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Status: 200 OK
Cache-Control: private, max-age=0, must-revalidate
Strict-Transport-Security: max-age=2592000
X-Frame-Options: deny
Content-Length: 27
Vary: Accept-Encoding

error=bad_verification_code
```
At the moment, this situation is treated as a success (access_code=undefined). 

This change allows `passport-oauth2` to spot the error and fail accordingly. I would prefer to keep this in the `passport-github` module, but the strategy does not allow it to be handled at that level as far as I can see.