### PR TITLE
There is no mentions  in readme.md about `connect.query()` middleware dependency 

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -119,6 +119,10 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
   
+  if (!req.query)
+    return this.error(new Error('OAuth2Strategy requires query support. Did you forget app.use(connect.query())?'));
+
+  
   if (req.query && req.query.error) {
     if (req.query.error == 'access_denied') {
       return this.fail({ message: req.query.error_description });


### PR DESCRIPTION
Missing `connect.query()` middleware may cause infinite loop in authenticate workflow (`strategy.js:132` for example). I think it's very minor but may save time to somebody. 
