### PR TITLE
Remove type=web_server from redirect URLs

### DIFF
--- a/test/oauth2.normal.test.js
+++ b/test/oauth2.normal.test.js
@@ -145,7 +145,7 @@ describe('OAuth2Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
     });
   });
   
@@ -164,7 +164,7 @@ describe('OAuth2Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123&type=web_server');
+      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123');
     });
   });
   
@@ -183,7 +183,7 @@ describe('OAuth2Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=permission_1%20permission_2&client_id=ABC123&type=web_server');
+      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=permission_1%20permission_2&client_id=ABC123');
     });
   });
   
@@ -202,7 +202,7 @@ describe('OAuth2Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback%2Falt1&client_id=ABC123&type=web_server');
+      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback%2Falt1&client_id=ABC123');
     });
   });
   
@@ -224,7 +224,7 @@ describe('OAuth2Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback%2Falt2&client_id=ABC123&type=web_server');
+      expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback%2Falt2&client_id=ABC123');
     });
   });
   

--- a/test/oauth2.options.test.js
+++ b/test/oauth2.options.test.js
@@ -46,7 +46,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123');
       });
     });
   });
@@ -93,7 +93,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=permission_1%2Cpermission_2&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=permission_1%2Cpermission_2&client_id=ABC123');
       });
     });
   });
@@ -210,7 +210,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
   
@@ -232,7 +232,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
   
@@ -261,7 +261,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
   
@@ -291,7 +291,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
     
@@ -320,7 +320,7 @@ describe('OAuth2Strategy', function() {
       });
 
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
 
@@ -350,7 +350,7 @@ describe('OAuth2Strategy', function() {
       });
 
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fserver.internal%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=http%3A%2F%2Fserver.internal%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
   });
@@ -405,7 +405,7 @@ describe('OAuth2Strategy', function() {
       });
 
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
 
@@ -429,7 +429,7 @@ describe('OAuth2Strategy', function() {
       });
 
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
   });

--- a/test/oauth2.state.test.js
+++ b/test/oauth2.state.test.js
@@ -391,7 +391,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&state=foo123&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&state=foo123&client_id=ABC123');
       });
     });
     

--- a/test/oauth2.sub.authorizationparams.test.js
+++ b/test/oauth2.sub.authorizationparams.test.js
@@ -55,7 +55,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?prompt=mobile&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?prompt=mobile&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123');
       });
     });
     
@@ -74,7 +74,7 @@ describe('OAuth2Strategy', function() {
       });
   
       it('should be redirected', function() {
-        expect(url).to.equal('https://www.example.com/oauth2/authorize?prompt=mobile&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123&type=web_server');
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?prompt=mobile&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email&client_id=ABC123');
       });
     });
   });


### PR DESCRIPTION
As of version 0.9.11 the oauth npm no longer adds the type parameter
so we need to stop expecting to see it. Explanation at:

https://github.com/ciaranj/node-oauth/commit/8658d7d55be25528a091415ca01671e6ef2a9882
