### PR TITLE
Allow empty string for clientSecret

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -81,7 +81,7 @@ function OAuth2Strategy(options, verify) {
   if (!options.authorizationURL) { throw new TypeError('OAuth2Strategy requires a authorizationURL option'); }
   if (!options.tokenURL) { throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
   if (!options.clientID) { throw new TypeError('OAuth2Strategy requires a clientID option'); }
-  if (!options.clientSecret) { throw new TypeError('OAuth2Strategy requires a clientSecret option'); }
+  if (options.clientSecret == null) { throw new TypeError('OAuth2Strategy requires a clientSecret option'); }
   
   passport.Strategy.call(this);
   this.name = 'oauth2';


### PR DESCRIPTION
According to specs http://tools.ietf.org/html/rfc6749#section-2.3.1 client_secret MAY be an empty string