### PR TITLE
Allow state verification without requiring a session.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: "node_js"
 node_js:
   - "0.10"
   - "0.8"
-#  - "0.6"
-  - "0.4"
 
 before_install:
  - "npm install istanbul -g"

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@
  * Module dependencies.
  */
 var Strategy = require('./strategy')
+  , SessionStateProvider = require('./sessionstateprovider')
+  , TokenStateProvider = require('./tokenstateprovider')
   , AuthorizationError = require('./errors/authorizationerror')
   , TokenError = require('./errors/tokenerror')
   , InternalOAuthError = require('./errors/internaloautherror');
@@ -16,6 +18,12 @@ exports = module.exports = Strategy;
  * Export constructors.
  */
 exports.Strategy = Strategy;
+
+/**
+ * Export the state providers
+ */
+exports.SessionStateProvider = SessionStateProvider;
+exports.TokenStateProvider = TokenStateProvider;
 
 /**
  * Export errors.

--- a/lib/sessionstateprovider.js
+++ b/lib/sessionstateprovider.js
@@ -1,0 +1,90 @@
+var uid = require('uid2');
+
+/**
+ * Creates an instance of `SessionStateProvider`.
+ *
+ * This is the default state provider implementation for the OAuth2Strategy.
+ * If generates a random state and stores it in `req.session` under the `key`
+ * provided in the constructor.
+ *
+ * If no session exists, the provider will throw an error. If you are not using
+ * sessions, consider using `TokenStateProvider` instead.
+ *
+ * Options:
+ *
+ *   - `key`               The key in the session under which to store the session state
+ *
+ * @constructor
+ * @param {Object} options
+ * @api public
+ */
+function SessionStateProvider(options) {
+  if (!options.key) { throw new TypeError('SessionStateProvider requires a key'); }
+  this._key = options.key;
+}
+
+/**
+ * Given a request, returns a value to use as state.
+ *
+ * This implementation simply generates a random UID and stores the value in the session
+ * for validation at a later stage when `verify` is called.
+ *
+ * @param {Object} req
+ * @param {Function} callback
+ * @api protected
+ */
+SessionStateProvider.prototype.get = function(req, callback) {
+  if (!req.session) { return callback(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
+
+  var key = this._key;
+  var state = uid(24);
+  if (!req.session[key]) { req.session[key] = {}; }
+  req.session[key].state = state;
+  callback(null, state);
+};
+
+/**
+ * Given a request, and the state returned by the OAuth provider, verifies the state.
+ *
+ * This implementation simply compares the returned state to the one saved in the user's session.
+ * If they do not match, or no state is saved in the session, the call will fail.
+ * If there is no session, the call will return an error.
+ *
+ * The callback signature has two values (`err`, `failureCode`). On success, these are both
+ * undefined. On error, only `err` is definied and on failure, err will contain the failure object
+ * while `failureCode` will contain the failure code.
+ *
+ * @param {Object} req
+ * @param {String} providedState
+ * @param {Function} callback
+ * @api protected
+ */
+SessionStateProvider.prototype.verify = function(req, providedState, callback) {
+  if (!req.session) { return callback(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
+
+  var key = this._key;
+  if (!req.session[key]) {
+   return callback({ message: 'Unable to verify authorization request state.' }, 403);
+  }
+
+  var state = req.session[key].state;
+  if (!state) {
+   return callback({ message: 'Unable to verify authorization request state.' }, 403);
+  }
+
+  delete req.session[key].state;
+  if (Object.keys(req.session[key]).length === 0) {
+   delete req.session[key];
+  }
+
+  if (state !== providedState) {
+   return callback({ message: 'Invalid authorization request state.' }, 403);
+  }
+
+  return callback();
+};
+
+/**
+ * Expose `SessionStateProvider`.
+ */
+module.exports = SessionStateProvider;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -3,10 +3,10 @@
  */
 var passport = require('passport-strategy')
   , url = require('url')
-  , uid = require('uid2')
   , util = require('util')
   , utils = require('./utils')
   , OAuth2 = require('oauth').OAuth2
+  , SessionStateProvider = require('./sessionstateprovider')
   , AuthorizationError = require('./errors/authorizationerror')
   , TokenError = require('./errors/tokenerror')
   , InternalOAuthError = require('./errors/internaloautherror');
@@ -76,13 +76,13 @@ function OAuth2Strategy(options, verify) {
     options = undefined;
   }
   options = options || {};
-  
+
   if (!verify) { throw new TypeError('OAuth2Strategy requires a verify callback'); }
   if (!options.authorizationURL) { throw new TypeError('OAuth2Strategy requires a authorizationURL option'); }
   if (!options.tokenURL) { throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
   if (!options.clientID) { throw new TypeError('OAuth2Strategy requires a clientID option'); }
   if (!options.clientSecret) { throw new TypeError('OAuth2Strategy requires a clientSecret option'); }
-  
+
   passport.Strategy.call(this);
   this.name = 'oauth2';
   this._verify = verify;
@@ -96,8 +96,15 @@ function OAuth2Strategy(options, verify) {
   this._callbackURL = options.callbackURL;
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
-  this._state = options.state;
   this._key = options.sessionKey || ('oauth2:' + url.parse(options.authorizationURL).hostname);
+
+  if (options.stateProvider) {
+    this._stateProvider = options.stateProvider;
+  } else {
+    if (options.state) {
+      this._stateProvider = new SessionStateProvider({ key: this._key });
+    }
+  }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
@@ -118,7 +125,7 @@ util.inherits(OAuth2Strategy, passport.Strategy);
 OAuth2Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req.query && req.query.error) {
     if (req.query.error == 'access_denied') {
       return this.fail({ message: req.query.error_description });
@@ -126,7 +133,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
     }
   }
-  
+
   var callbackURL = options.callbackURL || this._callbackURL;
   if (callbackURL) {
     var parsed = url.parse(callbackURL);
@@ -136,71 +143,29 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy }), callbackURL);
     }
   }
-  
+
   if (req.query && req.query.code) {
-    var code = req.query.code;
-    
-    if (this._state) {
-      if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
-      var key = this._key;
-      if (!req.session[key]) {
-        return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
-      }
-      var state = req.session[key].state;
-      if (!state) {
-        return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
-      }
-      
-      delete req.session[key].state;
-      if (Object.keys(req.session[key]).length === 0) {
-        delete req.session[key];
-      }
-      
-      if (state !== req.query.state) {
-        return this.fail({ message: 'Invalid authorization request state.' }, 403);
-      }
+    if (this._stateProvider) {
+      var state = req.query.state;
+      this._stateProvider.verify(req, state, function(errOrFailure, failureCode) {
+        if (errOrFailure) {
+          /* If verify returns a failureCode, err is a failure, otherwise it's an error */
+          if (failureCode) {
+            return self.fail(errOrFailure, failureCode);
+          }
+
+          return self.error(errOrFailure);
+        }
+
+        /* Proceed with token exchange */
+        self._getOAuthAccessToken(req, callbackURL, options);
+      });
+
+      return;
     }
 
-    var params = this.tokenParams(options);
-    params.grant_type = 'authorization_code';
-    params.redirect_uri = callbackURL;
+    this._getOAuthAccessToken(req, callbackURL, options);
 
-    this._oauth2.getOAuthAccessToken(code, params,
-      function(err, accessToken, refreshToken, params) {
-        if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-        
-        self._loadUserProfile(accessToken, function(err, profile) {
-          if (err) { return self.error(err); }
-          
-          function verified(err, user, info) {
-            if (err) { return self.error(err); }
-            if (!user) { return self.fail(info); }
-            self.success(user, info);
-          }
-          
-          try {
-            if (self._passReqToCallback) {
-              var arity = self._verify.length;
-              if (arity == 6) {
-                self._verify(req, accessToken, refreshToken, params, profile, verified);
-              } else { // arity == 5
-                self._verify(req, accessToken, refreshToken, profile, verified);
-              }
-            } else {
-              var arity = self._verify.length;
-              if (arity == 5) {
-                self._verify(accessToken, refreshToken, params, profile, verified);
-              } else { // arity == 4
-                self._verify(accessToken, refreshToken, profile, verified);
-              }
-            }
-          } catch (ex) {
-            return self.error(ex);
-          }
-        });
-      }
-    );
   } else {
     var params = this.authorizationParams(options);
     params.response_type = 'code';
@@ -210,21 +175,23 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       if (Array.isArray(scope)) { scope = scope.join(this._scopeSeparator); }
       params.scope = scope;
     }
+
     var state = options.state;
     if (state) {
       params.state = state;
-    } else if (this._state) {
-      if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
-      var key = this._key;
-      state = uid(24);
-      if (!req.session[key]) { req.session[key] = {}; }
-      req.session[key].state = state;
-      params.state = state;
+    } else if (this._stateProvider) {
+      /* Use the state provider if one is available */
+      this._stateProvider.get(req, function(err, state) {
+        if (err) { return self.error(err); }
+
+        params.state = state;
+        self._redirectWithParams(params);
+      });
+
+      return;
     }
-    
-    var location = this._oauth2.getAuthorizeUrl(params);
-    this.redirect(location);
+
+    this._redirectWithParams(params);
   }
 };
 
@@ -301,6 +268,59 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
 };
 
 /**
+ * Exchange the code provided on the request for an access token
+ *
+ * @param {Object} req
+ * @param {String} callbackURL
+ * @param {Object} options
+ * @api private
+ */
+OAuth2Strategy.prototype._getOAuthAccessToken = function(req, callbackURL, options) {
+  var code = req.query.code;
+  var self = this;
+
+  var params = this.tokenParams(options);
+  params.grant_type = 'authorization_code';
+  params.redirect_uri = callbackURL;
+
+  this._oauth2.getOAuthAccessToken(code, params,
+    function(err, accessToken, refreshToken, params) {
+      if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+
+      self._loadUserProfile(accessToken, function(err, profile) {
+        if (err) { return self.error(err); }
+
+        function verified(err, user, info) {
+          if (err) { return self.error(err); }
+          if (!user) { return self.fail(info); }
+          self.success(user, info);
+        }
+
+        try {
+          if (self._passReqToCallback) {
+            var arity = self._verify.length;
+            if (arity == 6) {
+              self._verify(req, accessToken, refreshToken, params, profile, verified);
+            } else { // arity == 5
+              self._verify(req, accessToken, refreshToken, profile, verified);
+            }
+          } else {
+            var arity = self._verify.length;
+            if (arity == 5) {
+              self._verify(accessToken, refreshToken, params, profile, verified);
+            } else { // arity == 4
+              self._verify(accessToken, refreshToken, profile, verified);
+            }
+          }
+        } catch (ex) {
+          return self.error(ex);
+        }
+      });
+    }
+  );
+};
+
+/**
  * Load user profile, contingent upon options.
  *
  * @param {String} accessToken
@@ -309,14 +329,14 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
  */
 OAuth2Strategy.prototype._loadUserProfile = function(accessToken, done) {
   var self = this;
-  
+
   function loadIt() {
     return self.userProfile(accessToken, done);
   }
   function skipIt() {
     return done(null);
   }
-  
+
   if (typeof this._skipUserProfile == 'function' && this._skipUserProfile.length > 1) {
     // async
     this._skipUserProfile(accessToken, function(err, skip) {
@@ -349,6 +369,16 @@ OAuth2Strategy.prototype._createOAuthError = function(message, err) {
   return e;
 };
 
+/**
+ * Redirect to the oAuth provider, given query params
+ *
+ * @param {Object} params
+ * @api private
+ */
+OAuth2Strategy.prototype._redirectWithParams = function(params) {
+  var location = this._oauth2.getAuthorizeUrl(params);
+  this.redirect(location);
+};
 
 /**
  * Expose `OAuth2Strategy`.

--- a/lib/tokenstateprovider.js
+++ b/lib/tokenstateprovider.js
@@ -1,0 +1,99 @@
+var uid = require('uid2')
+  , crypto = require('crypto');
+
+/**
+ * Creates an instance of `TokenStateProvider`.
+ *
+ * The token state provider is useful if you want to use OAuth state verification
+ * without using session state on the client. It's also useful if you users take
+ * longer than your session timeout to complete the OAuth login.
+ *
+ * Options:
+ *
+ *   - `passphrase`         A passphrase used for encrypting tokens. Make sure it's secure.
+ *   - `cipher`             The cipher to use for encryption. Defaults to `aes128`.
+ *   - `maxTokenAge`        The maximum age, in seconds, for a token before it's rejected. Defaults to one day.
+ *
+ * @constructor
+ * @param {Object} options
+ * @api public
+ */
+function TokenStateProvider(options) {
+  if (!options.passphrase) { throw new TypeError('TokenStateProvider requires a passphrase'); }
+  this._passphrase = options.passphrase;
+  this._cipher = options.cipher || 'aes128';
+  this._maxTokenAge = (options.maxTokenAge || 86400) * 1000;
+}
+
+/**
+ * Generates a token using a random salt and the time.
+ *
+ * @param {Object} req
+ * @param {Function} callback
+ * @api protected
+ */
+TokenStateProvider.prototype.get = function(req, callback) {
+  /* random = Salt + time */
+  var random = uid(4) + ':' + Date.now().toString(16);
+
+  var cipher = crypto.createCipher(this._cipher, this._passphrase);
+  var state = cipher.update(random, 'ascii', 'hex') + cipher.final('hex');
+
+  callback(null, state);
+};
+
+/**
+ * Given a request, and the state returned by the OAuth provider, verifies the state.
+ *
+ * The state is decrypted using the passphrase, resulting in a salt plus the time.
+ * Additionally, the time is validated to ensure that the time does not exceed the
+ * bounds of [now - `maxTokenAge`..now + 60 seconds]
+ *
+ * The 60 second buffer on the time allows tokens to be generated on different servers in a
+ * cluster which may have varing times, although if there's a 60 second difference you
+ * may want to consider sorting out your `ntpd` issues first.
+ *
+ * @param {Object} req
+ * @param {String} providedState
+ * @param {Function} callback
+ * @api protected
+ */
+TokenStateProvider.prototype.verify = function(req, providedState, callback) {
+  if (!providedState) { return callback({ message: 'Invalid authorization request state.' }, 403); }
+
+  try {
+    var decipher = crypto.createDecipher(this._cipher, this._passphrase);
+    var decrypted = decipher.update(providedState, 'hex', 'ascii') + decipher.final('ascii');
+
+    if (this._verifyDecrypted(decrypted)) {
+      return callback();
+    } else {
+      return callback({ message: 'Invalid authorization request state.' }, 403);
+    }
+
+  } catch(e) {
+    return callback({ message: 'Invalid authorization request state.' }, 403);
+  }
+};
+
+/**
+ * Verify that a successfully decrypted token is valid.
+ *
+ * @param {String} decrypted
+ * @api private
+ */
+TokenStateProvider.prototype._verifyDecrypted = function(decrypted) {
+  var parts = decrypted.split(':', 2);
+  if (parts[0].length !== 4) { return false; }
+  var generatedAt = parseInt(parts[1], 16);
+  var now = Date.now();
+
+  return generatedAt &&
+    generatedAt > now - this._maxTokenAge &&
+    generatedAt < now + 60000; /* Allow for server clock skew */
+};
+
+/**
+ * Expose `TokenStateProvider`.
+ */
+module.exports = TokenStateProvider;

--- a/test/oauth2.token.state.test.js
+++ b/test/oauth2.token.state.test.js
@@ -1,0 +1,126 @@
+var chai = require('chai')
+  , uri = require('url')
+  , TokenStateProvider = require('../lib/tokenstateprovider');
+
+
+describe('TokenStateProvider', function() {
+
+  var tokenStateProvider = new TokenStateProvider({ passphrase: 'correcthorsebatterystaple' });
+
+  describe('should generate states', function() {
+    var err
+      , state;
+
+    before(function(done) {
+      tokenStateProvider.get({}, function(e, s) {
+        err = e;
+        state = s;
+        done();
+      });
+    });
+
+    it('should not error', function() {
+      expect(err).to.not.exist;
+    });
+
+    it('should have generated a token', function() {
+      expect(state).to.have.length.above(12);
+    });
+  });
+
+  describe('should verify generated states', function() {
+    var err
+      , failureCode;
+
+    before(function(done) {
+      tokenStateProvider.get({}, function(err, state) {
+        if (err) { return done(err); }
+        tokenStateProvider.verify({}, state, function(e, f) {
+          err = e;
+          failureCode = f;
+          done();
+        })
+      });
+    });
+
+    it('should not error', function() {
+      expect(err).to.not.exist;
+    });
+
+    it('should not have a failure code', function() {
+      expect(failureCode).to.not.exist;
+    });
+
+  });
+
+  describe('should not verify invalid states', function() {
+    var errOrFailure
+      , failureCode;
+
+    before(function(done) {
+      tokenStateProvider.verify({}, '8980c099ec7024de7f710694f04fbd58', function(e, f) {
+        errOrFailure = e;
+        failureCode = f;
+        done();
+      });
+    });
+
+    it('should an error', function() {
+      expect(errOrFailure).to.be.an.object;
+      expect(errOrFailure.message).to.equal('Invalid authorization request state.');
+    });
+
+    it('should not have a failure code', function() {
+      expect(failureCode).to.equal(403);
+    });
+
+  });
+
+  describe('should not verify old tokens', function() {
+    var errOrFailure
+      , failureCode;
+
+    before(function(done) {
+      tokenStateProvider.verify({}, '0d07694f432e5b2e002f25a4cd6906a3c238605c1e7a089ba3f750b29b60a022', function(e, f) {
+        errOrFailure = e;
+        failureCode = f;
+        done();
+      });
+    });
+
+    it('should an error', function() {
+      expect(errOrFailure).to.be.an.object;
+      expect(errOrFailure.message).to.equal('Invalid authorization request state.');
+    });
+
+    it('should not have a failure code', function() {
+      expect(failureCode).to.equal(403);
+    });
+
+  });
+
+  describe('should not verify old tokens', function() {
+    var errOrFailure
+      , failureCode;
+
+    before(function(done) {
+      tokenStateProvider.verify({}, '', function(e, f) {
+        errOrFailure = e;
+        failureCode = f;
+        done();
+      });
+    });
+
+    it('should an error', function() {
+      expect(errOrFailure).to.be.an.object;
+      expect(errOrFailure.message).to.equal('Invalid authorization request state.');
+    });
+
+    it('should not have a failure code', function() {
+      expect(failureCode).to.equal(403);
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
### The problem

Currently, if you want to verify the `?state=` parameter in the OAuth2 callback, you are required to have a session for the user. If you web application does not use sessions, or if it's possible that the user's authentication period on the remote site takes longer than your session timeout, it's not possible to use state verification with this module.

### What does this PR do

The generation and verification of state has been abstracted out of the strategy into a separate class, `SessionStateProvider`. The default behaviour when setting `state: true` in the options hash remains the same in that a new `SessionStateProvider` is instantiated and used. However the PR makes it possible to use an alternative mechanism for verifying state via the `stateProvider: ` option. 

The alternative provided with this PR is the `TokenStateProvider`. It can be used to generate cryptographically secure tokens which can be verified without the need for saving state on the server. A salt plus the current time are encrypted and used as the token. On verification, the state is decrypted and the result verified.

To use it, specify `stateProvider: new TokenStateProvider({ passphrase: 'keyboardcat' })` in the `OAuth2Strategy` options.

Let me know if there's anything you want me to change!

Thanks
Andrew