### PR TITLE
made redirectUriParam configurable

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
   "node": true,
   "bitwise": true,
-  "camelcase": true,
+  "camelcase": false,
   "curly": true,
   "forin": true,
   "immed": true,

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,15 +1,15 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport-strategy')
-  , url = require('url')
-  , uid = require('uid2')
-  , util = require('util')
-  , utils = require('./utils')
-  , OAuth2 = require('oauth').OAuth2
-  , AuthorizationError = require('./errors/authorizationerror')
-  , TokenError = require('./errors/tokenerror')
-  , InternalOAuthError = require('./errors/internaloautherror');
+var passport = require('passport-strategy'),
+  url = require('url'),
+  uid = require('uid2'),
+  util = require('util'),
+  utils = require('./utils'),
+  OAuth2 = require('oauth').OAuth2,
+  AuthorizationError = require('./errors/authorizationerror'),
+  TokenError = require('./errors/tokenerror'),
+  InternalOAuthError = require('./errors/internaloautherror');
 
 
 /**
@@ -76,13 +76,23 @@ function OAuth2Strategy(options, verify) {
     options = undefined;
   }
   options = options || {};
-  
-  if (!verify) { throw new TypeError('OAuth2Strategy requires a verify callback'); }
-  if (!options.authorizationURL) { throw new TypeError('OAuth2Strategy requires a authorizationURL option'); }
-  if (!options.tokenURL) { throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
-  if (!options.clientID) { throw new TypeError('OAuth2Strategy requires a clientID option'); }
-  if (!options.clientSecret) { throw new TypeError('OAuth2Strategy requires a clientSecret option'); }
-  
+
+  if (!verify) {
+    throw new TypeError('OAuth2Strategy requires a verify callback');
+  }
+  if (!options.authorizationURL) {
+    throw new TypeError('OAuth2Strategy requires a authorizationURL option');
+  }
+  if (!options.tokenURL) {
+    throw new TypeError('OAuth2Strategy requires a tokenURL option');
+  }
+  if (!options.clientID) {
+    throw new TypeError('OAuth2Strategy requires a clientID option');
+  }
+  if (!options.clientSecret) {
+    throw new TypeError('OAuth2Strategy requires a clientSecret option');
+  }
+
   passport.Strategy.call(this);
   this.name = 'oauth2';
   this._verify = verify;
@@ -90,10 +100,11 @@ function OAuth2Strategy(options, verify) {
   // NOTE: The _oauth2 property is considered "protected".  Subclasses are
   //       allowed to use it when making protected resource requests to retrieve
   //       the user profile.
-  this._oauth2 = new OAuth2(options.clientID,  options.clientSecret,
-      '', options.authorizationURL, options.tokenURL, options.customHeaders);
+  this._oauth2 = new OAuth2(options.clientID, options.clientSecret,
+    '', options.authorizationURL, options.tokenURL, options.customHeaders);
 
   this._callbackURL = options.callbackURL;
+  this._redirectUriParam = options.redirectUriParam || 'redirect_uri';
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._state = options.state;
@@ -118,77 +129,99 @@ util.inherits(OAuth2Strategy, passport.Strategy);
 OAuth2Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+  var params, state, key;
+
   if (req.query && req.query.error) {
     if (req.query.error == 'access_denied') {
-      return this.fail({ message: req.query.error_description });
+      return this.fail({
+        message: req.query.error_description
+      });
     } else {
       return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
     }
   }
-  
+
   var callbackURL = options.callbackURL || this._callbackURL;
   if (callbackURL) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the
       // URL of the originating request.
-      callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy }), callbackURL);
+      callbackURL = url.resolve(utils.originalURL(req, {
+        proxy: this._trustProxy
+      }), callbackURL);
     }
   }
-  
+
   if (req.query && req.query.code) {
     var code = req.query.code;
-    
+
     if (this._state) {
-      if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
-      var key = this._key;
+      if (!req.session) {
+        return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?'));
+      }
+
+      key = this._key;
       if (!req.session[key]) {
-        return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
+        return this.fail({
+          message: 'Unable to verify authorization request state.'
+        }, 403);
       }
-      var state = req.session[key].state;
+      state = req.session[key].state;
       if (!state) {
-        return this.fail({ message: 'Unable to verify authorization request state.' }, 403);
+        return this.fail({
+          message: 'Unable to verify authorization request state.'
+        }, 403);
       }
-      
+
       delete req.session[key].state;
       if (Object.keys(req.session[key]).length === 0) {
         delete req.session[key];
       }
-      
+
       if (state !== req.query.state) {
-        return this.fail({ message: 'Invalid authorization request state.' }, 403);
+        return this.fail({
+          message: 'Invalid authorization request state.'
+        }, 403);
       }
     }
 
-    var params = this.tokenParams(options);
+    params = this.tokenParams(options);
     params.grant_type = 'authorization_code';
-    params.redirect_uri = callbackURL;
+    params[self._redirectUriParam] = callbackURL;
 
     this._oauth2.getOAuthAccessToken(code, params,
       function(err, accessToken, refreshToken, params) {
-        if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-        
+        if (err) {
+          return self.error(self._createOAuthError('Failed to obtain access token', err));
+        }
+
         self._loadUserProfile(accessToken, function(err, profile) {
-          if (err) { return self.error(err); }
-          
+          var arity;
+          if (err) {
+            return self.error(err);
+          }
+
           function verified(err, user, info) {
-            if (err) { return self.error(err); }
-            if (!user) { return self.fail(info); }
+            if (err) {
+              return self.error(err);
+            }
+            if (!user) {
+              return self.fail(info);
+            }
             self.success(user, info);
           }
-          
+
           try {
             if (self._passReqToCallback) {
-              var arity = self._verify.length;
+              arity = self._verify.length;
               if (arity == 6) {
                 self._verify(req, accessToken, refreshToken, params, profile, verified);
               } else { // arity == 5
                 self._verify(req, accessToken, refreshToken, profile, verified);
               }
             } else {
-              var arity = self._verify.length;
+              arity = self._verify.length;
               if (arity == 5) {
                 self._verify(accessToken, refreshToken, params, profile, verified);
               } else { // arity == 4
@@ -202,27 +235,33 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       }
     );
   } else {
-    var params = this.authorizationParams(options);
+    params = this.authorizationParams(options);
     params.response_type = 'code';
-    params.redirect_uri = callbackURL;
+    params[self._redirectUriParam] = callbackURL;
     var scope = options.scope || this._scope;
     if (scope) {
-      if (Array.isArray(scope)) { scope = scope.join(this._scopeSeparator); }
+      if (Array.isArray(scope)) {
+        scope = scope.join(this._scopeSeparator);
+      }
       params.scope = scope;
     }
-    var state = options.state;
+    state = options.state;
     if (state) {
       params.state = state;
     } else if (this._state) {
-      if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
-      
-      var key = this._key;
+      if (!req.session) {
+        return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?'));
+      }
+
+      key = this._key;
       state = uid(24);
-      if (!req.session[key]) { req.session[key] = {}; }
+      if (!req.session[key]) {
+        req.session[key] = {};
+      }
       req.session[key].state = state;
       params.state = state;
     }
-    
+
     var location = this._oauth2.getAuthorizeUrl(params);
     this.redirect(location);
   }
@@ -309,24 +348,31 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
  */
 OAuth2Strategy.prototype._loadUserProfile = function(accessToken, done) {
   var self = this;
-  
+
   function loadIt() {
     return self.userProfile(accessToken, done);
   }
+
   function skipIt() {
     return done(null);
   }
-  
-  if (typeof this._skipUserProfile == 'function' && this._skipUserProfile.length > 1) {
+
+  if (typeof this._skipUserProfile === 'function' && this._skipUserProfile.length > 1) {
     // async
     this._skipUserProfile(accessToken, function(err, skip) {
-      if (err) { return done(err); }
-      if (!skip) { return loadIt(); }
+      if (err) {
+        return done(err);
+      }
+      if (!skip) {
+        return loadIt();
+      }
       return skipIt();
     });
   } else {
-    var skip = (typeof this._skipUserProfile == 'function') ? this._skipUserProfile() : this._skipUserProfile;
-    if (!skip) { return loadIt(); }
+    var skip = (typeof this._skipUserProfile === 'function') ? this._skipUserProfile() : this._skipUserProfile;
+    if (!skip) {
+      return loadIt();
+    }
     return skipIt();
   }
 };
@@ -345,7 +391,9 @@ OAuth2Strategy.prototype._createOAuthError = function(message, err) {
       e = this.parseErrorResponse(err.data, err.statusCode);
     } catch (_) {}
   }
-  if (!e) { e = new InternalOAuthError(message, err); }
+  if (!e) {
+    e = new InternalOAuthError(message, err);
+  }
   return e;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-oauth2",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "OAuth 2.0 authentication strategy for Passport.",
   "keywords": [
     "passport",
@@ -17,6 +17,10 @@
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
+  "contributors": [{
+    "name": "Benjamin Kroeger",
+    "email": "benjamin.kroeger@gmail.com"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/jaredhanson/passport-oauth2.git"
@@ -24,12 +28,10 @@
   "bugs": {
     "url": "http://github.com/jaredhanson/passport-oauth2/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "licenses": [{
+    "type": "MIT",
+    "url": "http://www.opensource.org/licenses/MIT"
+  }],
   "main": "./lib",
   "dependencies": {
     "passport-strategy": "1.x.x",


### PR DESCRIPTION
I had to deal with an environment that failed when "redirect_uri" was provided with exactly that name on authorization request. This environment expexted the parameter to be named "callback_uri". I made this name an optional configuration parameter on instantiation... defaults to "redirect_uri" if not provided.

Sorry for the format changes. My editor did these automatically and I only noticed after committing