### PR TITLE
add feature /auth/:provider?access_token=x&refresh_token=y

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -195,7 +195,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       });
     }
 
-    if (req.query.access_token &&) {
+    if (req.query.access_token) {
       var accessToken = req.query.access_token;
       var refreshToken = req.query.refresh_token;
       var params = this.tokenParams(options);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -137,7 +137,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   }
   
-  if (req.query && Object.keys(req.query).length) {
+  if (req.query && (req.query.access_token || req.query.code)) {
 
     if (this._state) {
       if (!req.session) { 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -137,11 +137,12 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   }
   
-  if (req.query && req.query.code) {
-    var code = req.query.code;
-    
+  if (req.query) {
+
     if (this._state) {
-      if (!req.session) { return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?')); }
+      if (!req.session) { 
+        return this.error(new Error('OAuth2Strategy requires session support when using state. Did you forget app.use(express.session(...))?'));
+      }
       
       var key = this._key;
       if (!req.session[key]) {
@@ -162,45 +163,58 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       }
     }
 
-    var params = this.tokenParams(options);
-    params.grant_type = 'authorization_code';
-    params.redirect_uri = callbackURL;
-
-    this._oauth2.getOAuthAccessToken(code, params,
-      function(err, accessToken, refreshToken, params) {
-        if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+    function loadUserProfile(accessToken, refreshToken, params) {
+      self._loadUserProfile(accessToken, function(err, profile) {
+        if (err) return self.error(err);
         
-        self._loadUserProfile(accessToken, function(err, profile) {
+        function verified(err, user, info) {
           if (err) { return self.error(err); }
-          
-          function verified(err, user, info) {
-            if (err) { return self.error(err); }
-            if (!user) { return self.fail(info); }
-            self.success(user, info);
-          }
-          
-          try {
-            if (self._passReqToCallback) {
-              var arity = self._verify.length;
-              if (arity == 6) {
-                self._verify(req, accessToken, refreshToken, params, profile, verified);
-              } else { // arity == 5
-                self._verify(req, accessToken, refreshToken, profile, verified);
-              }
-            } else {
-              var arity = self._verify.length;
-              if (arity == 5) {
-                self._verify(accessToken, refreshToken, params, profile, verified);
-              } else { // arity == 4
-                self._verify(accessToken, refreshToken, profile, verified);
-              }
+          if (!user) { return self.fail(info); }
+          self.success(user, info);
+        }
+
+        try {
+          if (self._passReqToCallback) {
+            var arity = self._verify.length;
+            if (arity == 6) {
+              self._verify(req, accessToken, refreshToken, params, profile, verified);
+            } else { // arity == 5
+              self._verify(req, accessToken, refreshToken, profile, verified);
             }
-          } catch (ex) {
-            return self.error(ex);
+          } else {
+            var arity = self._verify.length;
+            if (arity == 5) {
+              self._verify(accessToken, refreshToken, params, profile, verified);
+            } else { // arity == 4
+              self._verify(accessToken, refreshToken, profile, verified);
+            }
           }
-        });
-      }
-    );
+        } catch (ex) {
+          return self.error(ex);
+        }
+      });
+    }
+
+    if (req.query.access_token &&) {
+      var accessToken = req.query.access_token;
+      var refreshToken = req.query.refresh_token;
+      var params = this.tokenParams(options);
+      params.redirect_uri = callbackURL;
+      loadUserProfile(accessToken, refreshToken, params);
+    } else if (req.query.code) {
+      var code = req.query.code;
+      var params = this.tokenParams(options);
+      params.grant_type = 'authorization_code';
+      params.redirect_uri = callbackURL;
+      this._oauth2.getOAuthAccessToken(code, params,
+        function(err, accessToken, refreshToken, params) {
+          if (err) { 
+            return self.error(self._createOAuthError('Failed to obtain access token', err));
+          }
+          loadUserProfile(accessToken, refreshToken, params);
+        }
+      );
+    }
   } else {
     var params = this.authorizationParams(options);
     params.response_type = 'code';

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -137,7 +137,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   }
   
-  if (req.query) {
+  if (req.query && Object.keys(req.query).length) {
 
     if (this._state) {
       if (!req.session) { 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-oauth2",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "OAuth 2.0 authentication strategy for Passport.",
   "keywords": [
     "passport",


### PR DESCRIPTION
In my app, I'm done with fetching access_token and refresh_token at iOS/android, so at that time, I only want server to fetch the user datum and create a user instance at database. So I added another case than `code` and redirection.

/cc @jaredhanson 