### PR TITLE
Params error handling

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -169,7 +169,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     this._oauth2.getOAuthAccessToken(code, params,
       function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-        if (params && params.error) { return self.error(self._createOAuthError('Failed to obtain access token', params)); }
+        if (params && params.error) { return self.error(self._createOAuthError(util.format('Failed to obtain access token (%s)', params.error), params)); }
         
         self._loadUserProfile(accessToken, function(err, profile) {
           if (err) { return self.error(err); }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -169,6 +169,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     this._oauth2.getOAuthAccessToken(code, params,
       function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+        if (params && params.error) { return self.error(self._createOAuthError('Failed to obtain access token', params)); }
         
         self._loadUserProfile(accessToken, function(err, profile) {
           if (err) { return self.error(err); }


### PR DESCRIPTION
Attempt to fix non parsed errors of jaredhanson/passport-oauth2#21 according to oauth errors spec https://tools.ietf.org/html/draft-ietf-oauth-v2-07#section-5.1.6.