### PR TITLE
remove arguments.callee to be strict mode compatible

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -24,7 +24,7 @@ function AuthorizationError(message, code, uri, status) {
   }
   
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, AuthorizationError);
   this.name = 'AuthorizationError';
   this.message = message;
   this.code = code || 'server_error';

--- a/lib/errors/internaloautherror.js
+++ b/lib/errors/internaloautherror.js
@@ -12,7 +12,7 @@
  */
 function InternalOAuthError(message, err) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, InternalOAuthError);
   this.name = 'InternalOAuthError';
   this.message = message;
   this.oauthError = err;

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -16,7 +16,7 @@
  */
 function TokenError(message, code, uri, status) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, TokenError);
   this.name = 'TokenError';
   this.message = message;
   this.code = code || 'invalid_request';


### PR DESCRIPTION
`arguments.callee` isn't compatible with strict mode. This PR removes them. 