### PR TITLE
Added option to disable automatically resolving callback url

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -137,8 +137,12 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   }
 
+  if (options.autoResolveCallback === undefined) {
+    options.autoResolveCallback = true;
+  }
+
   var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
+  if (callbackURL && options.autoResolveCallback) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the


### PR DESCRIPTION
In regards to  [https://github.com/jaredhanson/passport-oauth2/issues/51](url), this is what I'm proposing: An option (just like passReqToCallback) to disable auto resolving callback urls, though, it will be passed in the call to passport.use() instead of the strategy options.