### PR TITLE
Expose session stores

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,9 @@
 var Strategy = require('./strategy')
   , AuthorizationError = require('./errors/authorizationerror')
   , TokenError = require('./errors/tokenerror')
-  , InternalOAuthError = require('./errors/internaloautherror');
+  , InternalOAuthError = require('./errors/internaloautherror')
+  , SessionStore = require('./state/session')
+  , NullStore = require('./state/null');
 
 
 // Expose Strategy.
@@ -14,3 +16,6 @@ exports.Strategy = Strategy;
 exports.AuthorizationError = AuthorizationError;
 exports.TokenError = TokenError;
 exports.InternalOAuthError = InternalOAuthError;
+
+exports.SessionStore = SessionStore;
+exports.NullStore = NullStore;


### PR DESCRIPTION
This allows other libraries or Passport strategies to leverage these stores as their defaults instead of implementing their own.