### PR TITLE
Updated the authentication call to check for the OAuth param for errors

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -163,7 +163,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
       self._oauth2.getOAuthAccessToken(code, params,
         function(err, accessToken, refreshToken, params) {
-          if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err));
+          if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err));}
           if (params.error) {
             var error = new Object();
             error.statusCode =  params.error;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -163,8 +163,13 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
       self._oauth2.getOAuthAccessToken(code, params,
         function(err, accessToken, refreshToken, params) {
-          if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-
+          if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err));
+          if (params.error) {
+            var error = new Object();
+            error.statusCode =  params.error;
+            error.data = params.error_description;
+            return self.error(self._createOAuthError('Failed to obtain access token', error));
+          }
           self._loadUserProfile(accessToken, function(err, profile) {
             if (err) { return self.error(err); }
 


### PR DESCRIPTION
Updated the authentication call to check for the OAuth param for errorsrs. If there is error, the code will now throw an InternalOAuthError with the error details. This will help in identifying the underlying error that has occured. This will address issue #37 