### PR TITLE
Less dependencies from Express

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/
 reports/
+.vscode/
 
 # Mac OS X
 .DS_Store

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -8,7 +8,8 @@ var passport = require('passport-strategy')
   , SessionStateStore = require('./state/session')
   , AuthorizationError = require('./errors/authorizationerror')
   , TokenError = require('./errors/tokenerror')
-  , InternalOAuthError = require('./errors/internaloautherror');
+  , InternalOAuthError = require('./errors/internaloautherror')
+  , querystring = require('querystring');
 
 
 /**
@@ -123,12 +124,13 @@ util.inherits(OAuth2Strategy, passport.Strategy);
 OAuth2Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
+  var query = getQuery(req);
 
-  if (req.query && req.query.error) {
-    if (req.query.error == 'access_denied') {
-      return this.fail({ message: req.query.error_description });
+  if (query && query.error) {
+    if (query.error == 'access_denied') {
+      return this.fail({ message: query.error_description });
     } else {
-      return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
+      return this.error(new AuthorizationError(query.error_description, query.error, query.error_uri));
     }
   }
 
@@ -148,14 +150,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     clientID: this._oauth2._clientId
   }
 
-  if (req.query && req.query.code) {
+  if (query && query.code) {
     function loaded(err, ok, state) {
       if (err) { return self.error(err); }
       if (!ok) {
         return self.fail(state, 403);
       }
   
-      var code = req.query.code;
+      var code = query.code;
 
       var params = self.tokenParams(options);
       params.grant_type = 'authorization_code';
@@ -201,7 +203,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       );
     }
     
-    var state = req.query.state;
+    var state = query.state;
     try {
       var arity = this._stateStore.verify.length;
       if (arity == 4) {
@@ -380,6 +382,24 @@ OAuth2Strategy.prototype._createOAuthError = function(message, err) {
   return e;
 };
 
+/**
+ * Return query params
+ * 
+ * @param {Object} req Node or Express request object
+ * @return {Object} Query params
+ */
+function getQuery(req) {
+  if (req.query) {
+    return req.query;
+  }
+
+  if (req.url) {
+    var parsedUrl = url.parse(req.url);
+    return querystring.parse(parsedUrl.query);
+  }
+
+  return {};
+}
 
 // Expose constructor.
 module.exports = OAuth2Strategy;


### PR DESCRIPTION
If use this strategy with "no Express.js" request object - will work incorrectly. I fix it.
Not all frameworks/libs do modify req.query, example Koa2 has only native request object and it not contains parsed query params.