### PR TITLE
adding responseType as parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -94,6 +94,7 @@ function OAuth2Strategy(options, verify) {
   this._callbackURL = options.callbackURL;
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
+  this._responseType = options.responseType || 'code';
   this._key = options.sessionKey || ('oauth2:' + url.parse(options.authorizationURL).hostname);
 
   if (options.store) {
@@ -133,6 +134,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
   }
 
   var callbackURL = options.callbackURL || this._callbackURL;
+  var responseType = options.responseType || this._responseType;
   if (callbackURL) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
@@ -214,7 +216,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   } else {
     var params = this.authorizationParams(options);
-    params.response_type = 'code';
+    params.response_type = responseType;
     if (callbackURL) { params.redirect_uri = callbackURL; }
     var scope = options.scope || this._scope;
     if (scope) {


### PR DESCRIPTION
I've got cases where the response_type is different from 'code', so I made a modification that leaves 'code' as default, but allows the user to enter the desired type of response_type.