### PR TITLE
Adding ability to specify a custom agent for OAuth2Strategy via customHeaders

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -108,6 +108,9 @@ function OAuth2Strategy(options, verify) {
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
+  if(options.customHeaders && options.customHeaders.agent != undefined){
+    this._oauth2.setAgent(options.customHeaders.agent);
+  }
 }
 
 // Inherit from `passport.Strategy`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-oauth2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "OAuth 2.0 authentication strategy for Passport.",
   "keywords": [
     "passport",

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -21,7 +21,7 @@ describe('OAuth2Strategy', function() {
         expect(strategy.name).to.equal('oauth2');
       });
     }); // with normal options
-    
+
     describe('without a verify callback', function() {
       it('should throw', function() {
         expect(function() {
@@ -452,7 +452,7 @@ describe('OAuth2Strategy', function() {
   
   
   describe('processing response to authorization request', function() {
-    
+
     describe('that was approved without redirect URI', function() {
       var strategy = new OAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -1705,5 +1705,29 @@ describe('OAuth2Strategy', function() {
     }); // processing response to authorization request
     
   }); // using a relative redirect URI
-  
+
+  describe('with custom agent in custom headers', function() {
+        var strategy = new OAuth2Strategy({
+          authorizationURL: 'https://www.example.com/oauth2/authorize',
+          tokenURL: 'https://www.example.com/oauth2/token',
+          clientID: 'ABC123',
+          clientSecret: 'secret',
+          callbackURL: '/auth/example/callback',
+          customHeaders: {
+            agent: 'Awesome agent'
+          }
+        },
+        function(accessToken, refreshToken, profile, done) {
+          if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
+          if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
+          if (typeof profile !== 'object') { return done(new Error('incorrect profile argument')); }
+          if (Object.keys(profile).length !== 0) { return done(new Error('incorrect profile argument')); }
+
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        });
+
+        it('should set agent in oauth2', function() {
+          expect(strategy._oauth2._agent).to.equal('Awesome agent');
+        });
+    }); 
 });


### PR DESCRIPTION
We experienced an issue where we needed to adjust http request agent configurations but could not find anyway of configuring passport oauth2Strategy to propagate those configurations to the underlying library. This PR should resolve that issue in a generic way that is hopefully applicable to future use cases as well.