### PR TITLE
Propagate token exchange params to load user method

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -141,7 +141,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy }), callbackURL);
     }
   }
-  
+
   var meta = {
     authorizationURL: this._oauth2._authorizeUrl,
     tokenURL: this._oauth2._accessTokenUrl,
@@ -154,7 +154,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       if (!ok) {
         return self.fail(state, 403);
       }
-  
+
       var code = req.query.code;
 
       var params = self.tokenParams(options);
@@ -165,13 +165,13 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
         function(err, accessToken, refreshToken, params) {
           if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
 
-          self._loadUserProfile(accessToken, function(err, profile) {
+          self._loadUserProfile(accessToken, params, function(err, profile) {
             if (err) { return self.error(err); }
 
             function verified(err, user, info) {
               if (err) { return self.error(err); }
               if (!user) { return self.fail(info); }
-              
+
               info = info || {};
               if (state) { info.state = state; }
               self.success(user, info);
@@ -200,7 +200,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
         }
       );
     }
-    
+
     var state = req.query.state;
     try {
       var arity = this._stateStore.verify.length;
@@ -225,7 +225,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     var state = options.state;
     if (state) {
       params.state = state;
-      
+
       var parsed = url.parse(this._oauth2._authorizeUrl, true);
       utils.merge(parsed.query, params);
       parsed.query['client_id'] = this._oauth2._clientId;
@@ -244,7 +244,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
         var location = url.format(parsed);
         self.redirect(location);
       }
-      
+
       try {
         var arity = this._stateStore.store.length;
         if (arity == 3) {
@@ -338,11 +338,16 @@ OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
  * @param {Function} done
  * @api private
  */
-OAuth2Strategy.prototype._loadUserProfile = function(accessToken, done) {
+OAuth2Strategy.prototype._loadUserProfile = function(accessToken, params, done) {
   var self = this;
 
   function loadIt() {
-    return self.userProfile(accessToken, done);
+    var arity = self.userProfile.length;
+    if (arity == 3) {
+      return self.userProfile(accessToken, params, done);
+    } else { // arity == 2
+      return self.userProfile(accessToken, done);
+    }
   }
   function skipIt() {
     return done(null);

--- a/test/oauth2.subclass.profile.test.js
+++ b/test/oauth2.subclass.profile.test.js
@@ -4,7 +4,7 @@ var OAuth2Strategy = require('../lib/strategy')
 
 
 describe('OAuth2Strategy subclass', function() {
-  
+
   describe('that overrides userProfile', function() {
     function FooOAuth2Strategy(options, verify) {
       OAuth2Strategy.call(this, options, verify);
@@ -13,13 +13,13 @@ describe('OAuth2Strategy subclass', function() {
 
     FooOAuth2Strategy.prototype.userProfile = function(accessToken, done) {
       if (accessToken === '666') { return done(new Error('something went wrong loading user profile')); }
-      
+
       if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
-      
+
       return done(null, { username: 'jaredhanson', location: 'Oakland, CA' });
     }
-    
-    
+
+
     describe('fetching user profile', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -32,19 +32,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile.username != 'jaredhanson') { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234', username: profile.username }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -73,7 +73,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // fetching user profile
-    
+
     describe('error fetching user profile', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -85,16 +85,16 @@ describe('OAuth2Strategy subclass', function() {
       function(accessToken, refreshToken, profile, done) {
         return done(new Error('verify callback should not be called'));
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '666', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var err;
 
       before(function(done) {
@@ -115,7 +115,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(err.message).to.equal('something went wrong loading user profile');
       });
     }); // error fetching user profile
-    
+
     describe('skipping user profile due to skipUserProfile option set to true', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -129,19 +129,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile !== undefined) { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234' }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -169,7 +169,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // skipping user profile due to skipUserProfile option set to true
-    
+
     describe('not skipping user profile due to skipUserProfile returning false', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -185,19 +185,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile.username != 'jaredhanson') { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234', username: profile.username }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -226,7 +226,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // not skipping user profile due to skipUserProfile returning false
-    
+
     describe('skipping user profile due to skipUserProfile returning true', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -242,19 +242,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile !== undefined) { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234' }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -282,7 +282,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // skipping user profile due to skipUserProfile returning true
-    
+
     describe('not skipping user profile due to skipUserProfile asynchronously returning false', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -292,7 +292,7 @@ describe('OAuth2Strategy subclass', function() {
         callbackURL: 'https://www.example.net/auth/example/callback',
         skipUserProfile: function(accessToken, done) {
           if (accessToken != '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect token argument')); }
-          
+
           return done(null, false);
         }
       },
@@ -300,19 +300,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile.username != 'jaredhanson') { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234', username: profile.username }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -341,7 +341,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // not skipping user profile due to skipUserProfile asynchronously returning false
-    
+
     describe('skipping user profile due to skipUserProfile asynchronously returning true', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -351,7 +351,7 @@ describe('OAuth2Strategy subclass', function() {
         callbackURL: 'https://www.example.net/auth/example/callback',
         skipUserProfile: function(accessToken, done) {
           if (accessToken != '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect token argument')); }
-          
+
           return done(null, true);
         }
       },
@@ -359,19 +359,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile !== undefined) { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234' }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var user
         , info;
 
@@ -399,7 +399,7 @@ describe('OAuth2Strategy subclass', function() {
         expect(info.message).to.equal('Hello');
       });
     }); // skipping user profile due to skipUserProfile asynchronously returning true
-    
+
     describe('error due to skipUserProfile asynchronously returning error', function() {
       var strategy = new FooOAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
@@ -415,19 +415,19 @@ describe('OAuth2Strategy subclass', function() {
         if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
         if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
         if (profile !== undefined) { return done(new Error('incorrect profile argument')); }
-        
+
         return done(null, { id: '1234' }, { message: 'Hello' });
       });
-      
+
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
         if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
         if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
-        
+
         return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
       }
-  
-  
+
+
       var request
         , err;
 
@@ -449,7 +449,80 @@ describe('OAuth2Strategy subclass', function() {
         expect(err.message).to.equal('something went wrong');
       });
     }); // error due to skipUserProfile asynchronously returning error
-    
+
   }); // that overrides userProfile
-  
+
+  describe('that overrides userProfile (with params)', function() {
+    function FooOAuth2Strategy(options, verify) {
+      OAuth2Strategy.call(this, options, verify);
+    }
+    util.inherits(FooOAuth2Strategy, OAuth2Strategy);
+
+    FooOAuth2Strategy.prototype.userProfile = function(accessToken, params, done) {
+      if (accessToken === '666') { return done(new Error('something went wrong loading user profile')); }
+
+      if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
+
+      if (params.token_type !== 'example') { return done(new Error('incorrect params argument')); }
+
+      if (typeof(done) !== 'function') { return done(new Error('incorrect done argument')); }
+
+      return done(null, { username: 'jaredhanson', location: 'Oakland, CA' });
+    }
+
+    describe('fetching user profile', function() {
+      var strategy = new FooOAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
+        if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
+        if (profile.username != 'jaredhanson') { return done(new Error('incorrect profile argument')); }
+
+        return done(null, { id: '1234', username: profile.username }, { message: 'Hello' });
+      });
+
+      strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
+        if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
+        if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
+        if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
+
+        return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
+      }
+
+
+      var user
+        , info;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+        expect(user.username).to.equal('jaredhanson');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Hello');
+      });
+    }); // fetching user profile
+  });
+
 });


### PR DESCRIPTION
Yahoo oauth2 implementation returns, in a non conformant way, the user_id (`xoauth_yahoo_guid`) as part of the token exchange response (https://developer.yahoo.com/oauth2/guide/flows_authcode/#step-5-exchange-refresh-token-for-new-access-token).

This is later needed to fetch the user profile.

This prs propagates the params object to the user profile method (only if it expects it, based on its signature)