### PR TITLE
Add https option in case some Load Balancer such GCE can not proxy HT…

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -106,6 +106,7 @@ function OAuth2Strategy(options, verify) {
     }
   }
   this._trustProxy = options.proxy;
+  this._https = options.https;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
 }
@@ -138,7 +139,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the
       // URL of the originating request.
-      callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy }), callbackURL);
+      callbackURL = url.resolve(utils.originalURL(req, { proxy: this._trustProxy, https: this._https }), callbackURL);
     }
   }
   

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,9 +22,10 @@ exports.originalURL = function(req, options) {
     options.proxy = true;
   }
   var trustProxy = options.proxy;
+  var https = options.https;
   
   var proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
-    , tls = req.connection.encrypted || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0])
+    , tls = req.connection.encrypted || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0]) || https
     , host = (trustProxy && req.headers['x-forwarded-host']) || req.headers.host
     , protocol = tls ? 'https' : 'http'
     , path = req.url || '';


### PR DESCRIPTION
Add https option in case some Load Balancer such GCE can not proxy HTTPS in environment such k8s architecture.
Related [2509](https://github.com/eggjs/egg/issues/2509)