### PR TITLE
Fix conditional statement to store state when `state` is true

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -223,7 +223,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
 
     var state = options.state;
-    if (state) {
+    if (!state) {
       params.state = state;
       
       var parsed = url.parse(this._oauth2._authorizeUrl, true);


### PR DESCRIPTION
Passing `state: true` in the options causes authentication to skip storing the state in the SessionStore, which causes the verify callback to fail because the SessionStore is empty. This appears to be a typo. 
May resolve #88 and #57