### PR TITLE
feat(response_type): response_type in options

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -214,7 +214,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   } else {
     var params = this.authorizationParams(options);
-    params.response_type = 'code';
+    params.response_type = options.response_type || 'code';
     if (callbackURL) { params.redirect_uri = callbackURL; }
     var scope = options.scope || this._scope;
     if (scope) {


### PR DESCRIPTION
response_type is fixed by limiting the authentication options. What I did was check if there is response_type in the options, if it has, I hedge response_type, if not, code.