### PR TITLE
Enhanced support for PKCE.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ node_js:
   - "1" # io.js
   - "0.12"
   - "0.10"
-  - "0.8"
 
 
 # NOTE: `istanbul` and `coveralls` are pinned for compatibility with node 0.8.

--- a/lib/state/pkcesession.js
+++ b/lib/state/pkcesession.js
@@ -41,7 +41,7 @@ PKCESessionStore.prototype.store = function(req, verifier, state, meta, callback
   var key = this._key;
   var state = {
     handle: uid(24),
-    verifier: verifier
+    code_verifier: verifier
   };
   if (!req.session[key]) { req.session[key] = {}; }
   req.session[key].state = state;
@@ -81,7 +81,7 @@ PKCESessionStore.prototype.verify = function(req, providedState, callback) {
     return callback(null, false, { message: 'Invalid authorization request state.' });
   }
 
-  return callback(null, state.verifier);
+  return callback(null, state.code_verifier);
 };
 
 // Expose constructor.

--- a/lib/state/pkcesession.js
+++ b/lib/state/pkcesession.js
@@ -77,17 +77,11 @@ PKCESessionStore.prototype.verify = function(req, providedState, callback) {
     delete req.session[key];
   }
 
-  var checkState = state;
-  if (typeof state == 'object') {
-    checkState = state.handle;
-  }
-
-  if (checkState !== providedState) {
+  if (state.handle !== providedState) {
     return callback(null, false, { message: 'Invalid authorization request state.' });
   }
 
-  // FIXME: Do not return `state` value?
-  return callback(null, true, state);
+  return callback(null, state.verifier);
 };
 
 // Expose constructor.

--- a/lib/state/pkcesession.js
+++ b/lib/state/pkcesession.js
@@ -39,15 +39,12 @@ PKCESessionStore.prototype.store = function(req, verifier, state, meta, callback
   if (!req.session) { return callback(new Error('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
-  if (!req.session[key]) { req.session[key] = {}; }
-
   var state = {
     handle: uid(24),
     verifier: verifier
   };
-
+  if (!req.session[key]) { req.session[key] = {}; }
   req.session[key].state = state;
-
   callback(null, state.handle);
 };
 

--- a/lib/state/pkcesession.js
+++ b/lib/state/pkcesession.js
@@ -19,7 +19,7 @@ var uid = require('uid2');
  * @param {Object} options
  * @api public
  */
-function SessionStore(options) {
+function PKCESessionStore(options) {
   if (!options.key) { throw new TypeError('Session-based state store requires a session key'); }
   this._key = options.key;
 }
@@ -35,16 +35,20 @@ function SessionStore(options) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.store = function(req, callback) {
+PKCESessionStore.prototype.store = function(req, verifier, state, meta, callback) {
   if (!req.session) { return callback(new Error('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
   if (!req.session[key]) { req.session[key] = {}; }
 
-  var state = uid(24);
+  var state = {
+    handle: uid(24),
+    verifier: verifier
+  };
+
   req.session[key].state = state;
 
-  callback(null, state);
+  callback(null, state.handle);
 };
 
 /**
@@ -58,7 +62,7 @@ SessionStore.prototype.store = function(req, callback) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.verify = function(req, providedState, callback) {
+PKCESessionStore.prototype.verify = function(req, providedState, callback) {
   if (!req.session) { return callback(new Error('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
@@ -76,12 +80,18 @@ SessionStore.prototype.verify = function(req, providedState, callback) {
     delete req.session[key];
   }
 
-  if (state !== providedState) {
+  var checkState = state;
+  if (typeof state == 'object') {
+    checkState = state.handle;
+  }
+
+  if (checkState !== providedState) {
     return callback(null, false, { message: 'Invalid authorization request state.' });
   }
 
-  return callback(null, true);
+  // FIXME: Do not return `state` value?
+  return callback(null, true, state);
 };
 
 // Expose constructor.
-module.exports = SessionStore;
+module.exports = PKCESessionStore;

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -41,15 +41,16 @@ SessionStore.prototype.store = function(req, meta, callback) {
   var key = this._key;
   if (!req.session[key]) { req.session[key] = {}; }
 
-  var state = {};
-  state.handle = uid(24);
+  var state = uid(24);
 
   if (meta && meta.verifier) {
+    state = { handle: state };
     state.verifier = meta.verifier;
   }
 
   req.session[key].state = state;
 
+  // FIXME: callback should return a string only
   callback(null, state);
 };
 
@@ -82,10 +83,16 @@ SessionStore.prototype.verify = function(req, providedState, callback) {
     delete req.session[key];
   }
 
-  if (state.handle !== providedState) {
+  var checkState = state;
+  if (typeof state == 'object') {
+    checkState = state.handle;
+  }
+
+  if (checkState !== providedState) {
     return callback(null, false, { message: 'Invalid authorization request state.' });
   }
 
+  // FIXME: Do not return `state` value?
   return callback(null, true, state);
 };
 

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -50,8 +50,7 @@ SessionStore.prototype.store = function(req, meta, callback) {
 
   req.session[key].state = state;
 
-  // FIXME: callback should return a string only
-  callback(null, state);
+  callback(null, (typeof state == 'string') ? state : state.handle);
 };
 
 /**

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -39,11 +39,9 @@ SessionStore.prototype.store = function(req, callback) {
   if (!req.session) { return callback(new Error('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
-  if (!req.session[key]) { req.session[key] = {}; }
-
   var state = uid(24);
+  if (!req.session[key]) { req.session[key] = {}; }
   req.session[key].state = state;
-
   callback(null, state);
 };
 

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -35,7 +35,7 @@ function SessionStore(options) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.store = function(req, meta, callback) {
+SessionStore.prototype.store = function(req, verifier, state, meta, callback) {
   if (!req.session) { return callback(new Error('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
@@ -43,9 +43,9 @@ SessionStore.prototype.store = function(req, meta, callback) {
 
   var state = uid(24);
 
-  if (meta && meta.verifier) {
+  if (verifier) {
     state = { handle: state };
-    state.verifier = meta.verifier;
+    state.verifier = verifier;
   }
 
   req.session[key].state = state;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -107,6 +107,7 @@ function OAuth2Strategy(options, verify) {
     if (options.state) {
       this._stateStore = options.pkce ? new PKCESessionStateStore({ key: this._key }) : new SessionStateStore({ key: this._key });
     } else {
+      // TODO: throw error if PKCE is enabled
       this._stateStore = new NullStateStore();
     }
   }
@@ -150,8 +151,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
   var meta = {
     authorizationURL: this._oauth2._authorizeUrl,
     tokenURL: this._oauth2._accessTokenUrl,
-    clientID: this._oauth2._clientId,
-    pkceMethod: this._pkceMethod
+    clientID: this._oauth2._clientId
   }
 
   if (req.query && req.query.code) {
@@ -167,13 +167,13 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       params.grant_type = 'authorization_code';
       if (callbackURL) { params.redirect_uri = callbackURL; }
 
-      if (meta.pkceMethod) {
-        var verifier = state.verifier;
-        if (!verifier) {
+      if (self._pkceMethod) {
+        if (typeof ok != 'string') {
+          // TODO: shoud this be an error?
           return self.fail({ message: 'Unable to load stored code verifier.' }, 403);
         }
 
-        params.code_verifier = verifier;
+        params.code_verifier = ok;
       }
 
       self._oauth2.getOAuthAccessToken(code, params,

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -9,6 +9,7 @@ var passport = require('passport-strategy')
   , OAuth2 = require('oauth').OAuth2
   , NullStateStore = require('./state/null')
   , SessionStateStore = require('./state/session')
+  , PKCESessionStateStore = require('./state/pkcesession')
   , AuthorizationError = require('./errors/authorizationerror')
   , TokenError = require('./errors/tokenerror')
   , InternalOAuthError = require('./errors/internaloautherror');
@@ -104,7 +105,7 @@ function OAuth2Strategy(options, verify) {
     this._stateStore = options.store;
   } else {
     if (options.state) {
-      this._stateStore = new SessionStateStore({ key: this._key });
+      this._stateStore = options.pkce ? new PKCESessionStateStore({ key: this._key }) : new SessionStateStore({ key: this._key });
     } else {
       this._stateStore = new NullStateStore();
     }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -238,7 +238,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
     if (this._pkceMethod) {
       var verifier = base64url(crypto.pseudoRandomBytes(32))
-      , challenge;
+        , challenge;
 
       switch (this._pkceMethod) {
       case 'plain':

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -107,7 +107,7 @@ function OAuth2Strategy(options, verify) {
     if (options.state) {
       this._stateStore = options.pkce ? new PKCESessionStateStore({ key: this._key }) : new SessionStateStore({ key: this._key });
     } else {
-      // TODO: throw error if PKCE is enabled
+      if (options.pkce) { throw new TypeError('OAuth2Strategy requires `state: true` option when PKCE is enabled'); }
       this._stateStore = new NullStateStore();
     }
   }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -235,10 +235,10 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       if (Array.isArray(scope)) { scope = scope.join(this._scopeSeparator); }
       params.scope = scope;
     }
+    var verifier, challenge;
 
     if (this._pkceMethod) {
-      var verifier = base64url(crypto.pseudoRandomBytes(32))
-        , challenge;
+      verifier = base64url(crypto.pseudoRandomBytes(32))
 
       switch (this._pkceMethod) {
       case 'plain':
@@ -251,8 +251,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
         return this.error(new Error('Unsupported code verifier transformation method: ' + this._pkceMethod));
         break;
       }
-
-      meta.verifier = verifier;
+      
       params.code_challenge = challenge;
       params.code_challenge_method = this._pkceMethod;
     }
@@ -282,7 +281,9 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
       try {
         var arity = this._stateStore.store.length;
-        if (arity == 3) {
+        if (arity == 5) {
+          this._stateStore.store(req, verifier, undefined, meta, stored);
+        } else if (arity == 3) {
           this._stateStore.store(req, meta, stored);
         } else { // arity == 2
           this._stateStore.store(req, stored);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -97,7 +97,7 @@ function OAuth2Strategy(options, verify) {
   this._callbackURL = options.callbackURL;
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
-  this._pkceMethod = options.pkceMethod;
+  this._pkceMethod = (options.pkce === true) ? 'S256' : options.pkce;
   this._key = options.sessionKey || ('oauth2:' + url.parse(options.authorizationURL).hostname);
 
   if (options.store) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -271,7 +271,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       function stored(err, state) {
         if (err) { return self.error(err); }
 
-        if (state) { params.state = (typeof state === 'object') ? state.handle : state; }
+        if (state) { params.state = state; }
         var parsed = url.parse(self._oauth2._authorizeUrl, true);
         utils.merge(parsed.query, params);
         parsed.query['client_id'] = self._oauth2._clientId;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -241,9 +241,8 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       case 'S256':
         challenge = base64url(crypto.createHash('sha256').update(verifier).digest());
         break;
-      default: // not enabled
+      default:
         return this.error(new Error('Unsupported code verifier transformation method: ' + this._pkceMethod));
-        break;
       }
       
       params.code_challenge = challenge;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -166,8 +166,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       var params = self.tokenParams(options);
       params.grant_type = 'authorization_code';
       if (callbackURL) { params.redirect_uri = callbackURL; }
-      if (typeof ok == 'string') {
-        // PKCE
+      if (typeof ok == 'string') { // PKCE
         params.code_verifier = ok;
       }
 
@@ -235,7 +234,6 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
     if (this._pkceMethod) {
       verifier = base64url(crypto.pseudoRandomBytes(32))
-
       switch (this._pkceMethod) {
       case 'plain':
         challenge = verifier;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -166,13 +166,8 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       var params = self.tokenParams(options);
       params.grant_type = 'authorization_code';
       if (callbackURL) { params.redirect_uri = callbackURL; }
-
-      if (self._pkceMethod) {
-        if (typeof ok != 'string') {
-          // TODO: shoud this be an error?
-          return self.fail({ message: 'Unable to load stored code verifier.' }, 403);
-        }
-
+      if (typeof ok == 'string') {
+        // PKCE
         params.code_verifier = ok;
       }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "make-node": "0.4.6",
     "mocha": "2.x.x",
     "chai": "2.x.x",
-    "proxyquire": "1.x.x",
+    "proxyquire": "0.6.x",
     "chai-passport-strategy": "1.x.x"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "base64url": "^3.0.0",
+    "base64url": "3.x.x",
     "oauth": "0.9.x",
     "passport-strategy": "1.x.x",
     "uid2": "0.0.x",

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -439,5 +439,207 @@ describe('OAuth2Strategy', function() {
         expect(info).to.be.undefined;
       });
     });
+    
+    describe('that fails due to state being invalid', function() {
+      var OAuth2Strategy = require('proxyquire')('../lib/strategy', { crypto: mockCrypto });
+      var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        state: true,
+        pkce: 'S256'
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        }
+        return done(null, false);
+      });
+      
+      
+      var request
+        , info, status;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .fail(function(i, s) {
+            info = i;
+            status = s;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK-WRONG';
+            req.session = {};
+            req.session['oauth2:www.example.com'] = {};
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+          })
+          .authenticate();
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Invalid authorization request state.');
+      });
+    
+      it('should supply status', function() {
+        expect(status).to.equal(403);
+      });
+    
+      it('should remove state from session', function() {
+        expect(request.session['oauth2:www.example.com']).to.be.undefined;
+      });
+    }); // that fails due to state being invalid
+    
+    describe('that fails due to provider-specific state not found in session', function() {
+      var OAuth2Strategy = require('proxyquire')('../lib/strategy', { crypto: mockCrypto });
+      var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        state: true,
+        pkce: 'S256'
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        }
+        return done(null, false);
+      });
+      
+      
+      var request
+        , info, status;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .fail(function(i, s) {
+            info = i;
+            status = s;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
+            req.session = {};
+          })
+          .authenticate();
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Unable to verify authorization request state.');
+      });
+    
+      it('should supply status', function() {
+        expect(status).to.equal(403);
+      });
+    }); // that fails due to state not found in session
+    
+    describe('that fails due to provider-specific state lacking state value', function() {
+      var OAuth2Strategy = require('proxyquire')('../lib/strategy', { crypto: mockCrypto });
+      var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        state: true,
+        pkce: 'S256'
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        }
+        return done(null, false);
+      });
+      
+      
+      var request
+        , info, status;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .fail(function(i, s) {
+            info = i;
+            status = s;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
+            req.session = {};
+            req.session['oauth2:www.example.com'] = {};
+          })
+          .authenticate();
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Unable to verify authorization request state.');
+      });
+    
+      it('should supply status', function() {
+        expect(status).to.equal(403);
+      });
+    }); // that fails due to provider-specific state lacking state value
+    
+    describe('that errors due to lack of session support in app', function() {
+      var OAuth2Strategy = require('proxyquire')('../lib/strategy', { crypto: mockCrypto });
+      var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        state: true,
+        pkce: 'S256'
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        }
+        return done(null, false);
+      });
+      
+      
+      var request
+        , err;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .error(function(e) {
+            err = e;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
+          })
+          .authenticate();
+      });
+
+      it('should error', function() {
+        expect(err).to.be.an.instanceof(Error)
+        expect(err.message).to.equal('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?');
+      });
+    }); // that errors due to lack of session support in app
+    
   });
 });

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -418,9 +418,8 @@ describe('OAuth2Strategy', function() {
 
       before(function(done) {
         chai.passport.use(strategy)
-          .fail(function(e, code) {
-            err = e;
-            err.statusCode = code;
+          .fail(function(i) {
+            info = i;
             done();
           })
           .req(function(req) {
@@ -436,9 +435,8 @@ describe('OAuth2Strategy', function() {
           .authenticate();
       });
 
-      it('should error', function() {
-        expect(err.statusCode).to.equal(403);
-        expect(err.message).to.equal('Unable to load stored code verifier.');
+      it('should not supply info', function() {
+        expect(info).to.be.undefined;
       });
     });
   });

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -5,6 +5,119 @@ var chai = require('chai')
 
 describe('OAuth2Strategy', function() {
     
+  describe('with PKCE true transformation method', function() {
+    var mockCrypto = {
+      pseudoRandomBytes: function(len) {
+        if (len !== 32) { throw new Error('xyz'); }
+        // https://tools.ietf.org/html/rfc7636#appendix-B
+        return new Buffer(
+          [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
+          187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
+          132, 141, 121]
+        );
+      }
+    }
+    
+    var OAuth2Strategy = require('proxyquire')('../lib/strategy', { crypto: mockCrypto });
+    var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        state: true,
+        pkce: true
+      },
+      function(accessToken, refreshToken, profile, done) {
+        if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
+          return done(null, { id: '1234' }, { message: 'Hello' });
+        }
+        return done(null, false);
+      });
+
+    strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
+      if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
+      if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
+      if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
+      if (options.code_verifier !== 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk') { return callback(new Error('incorrect options.verifier loaded from session')); }
+
+      return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example' });
+    }
+
+    describe('handling a request to be redirected for authorization', function() {
+      var request, url;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .redirect(function(u) {
+            url = u;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.session = {};
+          })
+          .authenticate();
+      });
+
+      it('should be redirected', function() {
+        var u = uri.parse(url, true);
+        expect(u.query.state).to.have.length(24);
+        expect(u.query.code_challenge).to.have.length(43);
+        expect(u.query.code_challenge).to.equal('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM')
+        expect(u.query.code_challenge_method).to.equal('S256');
+      });
+    
+      it('should save verifier in session', function() {
+        var u = uri.parse(url, true);
+        expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
+        expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
+        expect(request.session['oauth2:www.example.com'].state.verifier).to.have.length(43);
+        expect(request.session['oauth2:www.example.com'].state.verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+      });
+    });
+
+    describe('processing response to authorization request', function() {
+      var request
+        , user
+        , info;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
+            req.session = {};
+            req.session['oauth2:www.example.com'] = {};
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+          })
+          .authenticate();
+      });
+
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Hello');
+      });
+
+      it('should remove state with verifier from session', function() {
+        expect(request.session['oauth2:www.example.com']).to.be.undefined;
+      });
+    });
+  });
+    
   describe('with PKCE plain transformation method', function() {
     var mockCrypto = {
       pseudoRandomBytes: function(len) {
@@ -25,7 +138,7 @@ describe('OAuth2Strategy', function() {
         clientSecret: 'secret',
         callbackURL: 'https://www.example.net/auth/example/callback',
         state: true,
-        pkceMethod: 'plain'
+        pkce: 'plain'
       },
       function(accessToken, refreshToken, profile, done) {
         if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
@@ -138,7 +251,7 @@ describe('OAuth2Strategy', function() {
         clientSecret: 'secret',
         callbackURL: 'https://www.example.net/auth/example/callback',
         state: true,
-        pkceMethod: 'S256'
+        pkce: 'S256'
       },
       function(accessToken, refreshToken, profile, done) {
         if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
@@ -253,7 +366,7 @@ describe('OAuth2Strategy', function() {
         clientSecret: 'secret',
         callbackURL: 'https://www.example.net/auth/example/callback',
         state: true,
-        pkceMethod: 'unknown'
+        pkce: 'unknown'
       },
       function(accessToken, refreshToken, profile, done) {
         if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 
@@ -292,7 +405,7 @@ describe('OAuth2Strategy', function() {
         clientSecret: 'secret',
         callbackURL: 'https://www.example.net/auth/example/callback',
         state: true,
-        pkceMethod: 'S256'
+        pkce: 'S256'
       },
       function(accessToken, refreshToken, profile, done) {
         if (accessToken == '2YotnFZFEjr1zCsicMWpAA' && refreshToken == 'tGzv3JOkF0XG5Qx2TlKWIA') { 

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -76,6 +76,42 @@ describe('OAuth2Strategy', function() {
         expect(request.session['oauth2:www.example.com'].state.code_verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
       });
     });
+    
+    describe('that redirects to service provider with other data in session', function() {
+      var request, url;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .redirect(function(u) {
+            url = u;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.session = {};
+            req.session['oauth2:www.example.com'] = {};
+            req.session['oauth2:www.example.com'].foo = 'bar';
+          })
+          .authenticate();
+      });
+
+      it('should be redirected', function() {
+        var u = uri.parse(url, true);
+        expect(u.query.state).to.have.length(24);
+      });
+    
+      it('should save state in session', function() {
+        var u = uri.parse(url, true);
+        expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
+        expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.have.length(43);
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+      });
+      
+      it('should preserve other data in session', function() {
+        expect(request.session['oauth2:www.example.com'].foo).to.equal('bar');
+      });
+    }); // that redirects to service provider with other data in session
 
     describe('processing response to authorization request', function() {
       var request
@@ -116,6 +152,69 @@ describe('OAuth2Strategy', function() {
         expect(request.session['oauth2:www.example.com']).to.be.undefined;
       });
     });
+    
+    describe('that was approved with other data in the session', function() {
+      var request
+        , user
+        , info;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+            req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
+            req.session = {};
+            req.session['oauth2:www.example.com'] = {};
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+            req.session['oauth2:www.example.com'].foo = 'bar';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Hello');
+      });
+    
+      it('should preserve other data from session', function() {
+        expect(request.session['oauth2:www.example.com'].state).to.be.undefined;
+        expect(request.session['oauth2:www.example.com'].foo).to.equal('bar');
+      });
+    }); // that was approved with other data in the session
+    
+    describe('that errors due to lack of session support in app', function() {
+      var request, err;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .error(function(e) {
+            err = e;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          })
+          .authenticate();
+      });
+
+      it('should error', function() {
+        expect(err).to.be.an.instanceof(Error)
+        expect(err.message).to.equal('OAuth 2.0 authentication requires session support when using state. Did you forget to use express-session middleware?');
+      });
+    }); // that errors due to lack of session support in app
   });
     
   describe('with PKCE plain transformation method', function() {

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -5,6 +5,21 @@ var chai = require('chai')
 
 describe('OAuth2Strategy', function() {
     
+  describe('without state:true option', function() {
+    it('should throw', function() {
+      expect(function() {
+        new OAuth2Strategy({
+          authorizationURL: 'https://www.example.com/oauth2/authorize',
+          tokenURL: 'https://www.example.com/oauth2/token',
+          clientID: 'ABC123',
+          clientSecret: 'secret',
+          callbackURL: 'https://www.example.net/auth/example/callback',
+          pkce: true
+        }, function() {});
+      }).to.throw(TypeError, 'OAuth2Strategy requires `state: true` option when PKCE is enabled');
+    });
+  }); // without a verify callback
+    
   describe('with PKCE true transformation method', function() {
     var mockCrypto = {
       pseudoRandomBytes: function(len) {

--- a/test/oauth2.pkce.test.js
+++ b/test/oauth2.pkce.test.js
@@ -72,8 +72,8 @@ describe('OAuth2Strategy', function() {
         var u = uri.parse(url, true);
         expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
         expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.have.length(43);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.have.length(43);
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
       });
     });
 
@@ -97,7 +97,7 @@ describe('OAuth2Strategy', function() {
             req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
             req.session = {};
             req.session['oauth2:www.example.com'] = {};
-            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
           })
           .authenticate();
       });
@@ -184,8 +184,8 @@ describe('OAuth2Strategy', function() {
         var u = uri.parse(url, true);
         expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
         expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.have.length(43);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.have.length(43);
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
       });
     });
 
@@ -209,7 +209,7 @@ describe('OAuth2Strategy', function() {
             req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
             req.session = {};
             req.session['oauth2:www.example.com'] = {};
-            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
           })
           .authenticate();
       });
@@ -297,8 +297,8 @@ describe('OAuth2Strategy', function() {
         var u = uri.parse(url, true);
         expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
         expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.have.length(43);
-        expect(request.session['oauth2:www.example.com'].state.verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.have.length(43);
+        expect(request.session['oauth2:www.example.com'].state.code_verifier).to.equal('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
       });
     });
 
@@ -322,7 +322,7 @@ describe('OAuth2Strategy', function() {
             req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
             req.session = {};
             req.session['oauth2:www.example.com'] = {};
-            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
+            req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK', code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk' };
           })
           .authenticate();
       });

--- a/test/oauth2.state.session.test.js
+++ b/test/oauth2.state.session.test.js
@@ -46,8 +46,8 @@ describe('OAuth2Strategy', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
-          expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
+          expect(request.session['oauth2:www.example.com'].state).to.have.length(24);
+          expect(request.session['oauth2:www.example.com'].state).to.equal(u.query.state);
         });
       }); // that redirects to service provider
       
@@ -77,8 +77,8 @@ describe('OAuth2Strategy', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
-          expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
+          expect(request.session['oauth2:www.example.com'].state).to.have.length(24);
+          expect(request.session['oauth2:www.example.com'].state).to.equal(u.query.state);
         });
         
         it('should preserve other data in session', function() {
@@ -146,8 +146,8 @@ describe('OAuth2Strategy', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['oauth2:www.example.com'].state.handle).to.have.length(24);
-          expect(request.session['oauth2:www.example.com'].state.handle).to.equal(u.query.state);
+          expect(request.session['oauth2:www.example.com'].state).to.have.length(24);
+          expect(request.session['oauth2:www.example.com'].state).to.equal(u.query.state);
         });
       }); // that redirects to service provider
       
@@ -200,7 +200,7 @@ describe('OAuth2Strategy', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['oauth2:www.example.com'] = {};
-              req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK' };
+              req.session['oauth2:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
             })
             .authenticate();
         });
@@ -240,7 +240,7 @@ describe('OAuth2Strategy', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['oauth2:www.example.com'] = {};
-              req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK' };
+              req.session['oauth2:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session['oauth2:www.example.com'].foo = 'bar';
             })
             .authenticate();
@@ -281,7 +281,7 @@ describe('OAuth2Strategy', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK-WRONG';
               req.session = {};
               req.session['oauth2:www.example.com'] = {};
-              req.session['oauth2:www.example.com']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK' };
+              req.session['oauth2:www.example.com']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
             })
             .authenticate();
         });
@@ -450,8 +450,8 @@ describe('OAuth2Strategy', function() {
         it('should save state in session', function() {
           var u = uri.parse(url, true);
         
-          expect(request.session['oauth2:example'].state.handle).to.have.length(24);
-          expect(request.session['oauth2:example'].state.handle).to.equal(u.query.state);
+          expect(request.session['oauth2:example'].state).to.have.length(24);
+          expect(request.session['oauth2:example'].state).to.equal(u.query.state);
         });
       }); // that redirects to service provider
       
@@ -479,7 +479,7 @@ describe('OAuth2Strategy', function() {
               req.query.state = 'DkbychwKu8kBaJoLE5yeR5NK';
               req.session = {};
               req.session['oauth2:example'] = {};
-              req.session['oauth2:example']['state'] = { handle: 'DkbychwKu8kBaJoLE5yeR5NK' };
+              req.session['oauth2:example']['state'] = 'DkbychwKu8kBaJoLE5yeR5NK';
             })
             .authenticate();
         });


### PR DESCRIPTION
This is a continuation of the work started by @sjudson in #69.

The primary functional modification is that it preserves the existing structure for serialized state when PKCE is not enabled.  This improves backwards compatibility, as the session-based state will be interpreted correctly, even as authorization responses are received, from which the request was issued by prior versions of `passport-oauth2`.

It also reworks, slightly, some of the internals of the session store itself.  These are minor changes, but made with an eye towards future enhancements.
