### PR TITLE
Remove unused source & rename param of getOAuthAccessToken callback

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -170,7 +170,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       }
 
       self._oauth2.getOAuthAccessToken(code, params,
-        function(err, accessToken, refreshToken, params) {
+        function(err, accessToken, refreshToken, results) {
           if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
 
           self._loadUserProfile(accessToken, function(err, profile) {
@@ -189,14 +189,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
               if (self._passReqToCallback) {
                 var arity = self._verify.length;
                 if (arity == 6) {
-                  self._verify(req, accessToken, refreshToken, params, profile, verified);
+                  self._verify(req, accessToken, refreshToken, results, profile, verified);
                 } else { // arity == 5
                   self._verify(req, accessToken, refreshToken, profile, verified);
                 }
               } else {
                 var arity = self._verify.length;
                 if (arity == 5) {
-                  self._verify(accessToken, refreshToken, params, profile, verified);
+                  self._verify(accessToken, refreshToken, results, profile, verified);
                 } else { // arity == 4
                   self._verify(accessToken, refreshToken, profile, verified);
                 }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,7 +1,6 @@
 // Load modules.
 var passport = require('passport-strategy')
   , url = require('url')
-  , uid = require('uid2')
   , crypto = require('crypto')
   , base64url = require('base64url')
   , util = require('util')


### PR DESCRIPTION
- Remove `uid = require('uid2')` declaration, since unused anymore.
- Rename param name `getOAuthAccessToken` callback: `params` => `results` for more understandable source code. Refs: https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js#L209