### PR TITLE
Add autoResolveCallback property to disabled auto attach the origin url to the callbackUrl

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,12 +45,13 @@ var passport = require('passport-strategy')
  *
  * Options:
  *
- *   - `authorizationURL`  URL used to obtain an authorization grant
- *   - `tokenURL`          URL used to obtain an access token
- *   - `clientID`          identifies client to service provider
- *   - `clientSecret`      secret used to establish ownership of the client identifer
- *   - `callbackURL`       URL to which the service provider will redirect the user after obtaining authorization
- *   - `passReqToCallback` when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *   - `authorizationURL`    URL used to obtain an authorization grant
+ *   - `tokenURL`            URL used to obtain an access token
+ *   - `clientID`            identifies client to service provider
+ *   - `clientSecret`        secret used to establish ownership of the client identifer
+ *   - `callbackURL`         URL to which the service provider will redirect the user after obtaining authorization
+ *   - `autoResolveCallback` whether to attach the origin url to the callbackUrl when using relative url (default: `true`)
+ *   - `passReqToCallback`   when `true`, `req` is the first argument to the verify callback (default: `false`)
  *
  * Examples:
  *
@@ -96,6 +97,7 @@ function OAuth2Strategy(options, verify) {
                             '', options.authorizationURL, options.tokenURL, options.customHeaders);
 
   this._callbackURL = options.callbackURL;
+  this._autoResolveCallback = options.autoResolveCallback !== false;
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._pkceMethod = (options.pkce === true) ? 'S256' : options.pkce;
@@ -139,7 +141,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
   }
 
   var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
+  if (callbackURL && this._autoResolveCallback) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the


### PR DESCRIPTION
In reference to #51 #52, this pull request resolved the conflicts, and create the new branch from latest master branch of passport-oauth2.

Add `autoResolveCallback` property to disabled auto attach the origin URL to the callbackUrl.