### PR TITLE
Pass HTTP status code to TokenError

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -355,7 +355,7 @@ OAuth2Strategy.prototype.tokenParams = function(options) {
 OAuth2Strategy.prototype.parseErrorResponse = function(body, status) {
   var json = JSON.parse(body);
   if (json.error) {
-    return new TokenError(json.error_description, json.error, json.error_uri);
+    return new TokenError(json.error_description, json.error, json.error_uri, status);
   }
   return null;
 };


### PR DESCRIPTION
Previously, when generating error responses, `TokenError` was not
passed the HTTP status code that was passed to the error response
handler (`parseErrorResponse`). This resulted in every kind of error
being treated as a 500 Internal Server Error. This commit fixes
this by passing on the returned status code from the OAuth call.

Fixes #127