### PR TITLE
Include check that access token was actually successfully returned

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -175,6 +175,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       self._oauth2.getOAuthAccessToken(code, params,
         function(err, accessToken, refreshToken, params) {
           if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+          if (!accessToken){ return self._createOAuthError('Failed to obtain access token', err)}
 
           self._loadUserProfile(accessToken, function(err, profile) {
             if (err) { return self.error(err); }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -174,8 +174,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 
       self._oauth2.getOAuthAccessToken(code, params,
         function(err, accessToken, refreshToken, params) {
-          if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-          if (!accessToken){ return self._createOAuthError('Failed to obtain access token', err)}
+          if (err || !accessToken) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
 
           self._loadUserProfile(accessToken, function(err, profile) {
             if (err) { return self.error(err); }


### PR DESCRIPTION
getOAuthAccessToken returns an error only if it is a HTTP error, if the identity provider does not follow OAuth2 standard and instead returns a status 200 indicating it is an error, authentication can still happen. I have therefore included a check to ensure some value for accessToken must have been returned. It is done here instead of the OAuth library because I saw that the OAuth library was last updated in 2017.

Do let me know if you have any concerns (not sure if will impact passport-facebook) and thank you for creating Passport and the various modules.

Separately, I have also raised a CVE for this so that everyone is more aware of this since if the identity provider returns unsuccessful but is a status 200, an empty authorization token to the callback URL will deem the user authenticated to the application.