### PR TITLE
Bump `oauth` from 0.9.x to 0.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "./lib",
   "dependencies": {
     "base64url": "3.x.x",
-    "oauth": "0.9.x",
+    "oauth": "0.10.x",
     "passport-strategy": "1.x.x",
     "uid2": "0.0.x",
     "utils-merge": "1.x.x"


### PR DESCRIPTION
This is solving issues of `passport-google-oauth2` as stated in issue [#163](https://github.com/jaredhanson/passport-oauth2/issues/163)