### PR TITLE
Don't swallow error if error and error_description are provided

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -175,6 +175,9 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
       self._oauth2.getOAuthAccessToken(code, params,
         function(err, accessToken, refreshToken, params) {
           if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+          if (!accessToken && params && params.error && params.error_description) {
+            return self.error(new TokenError(params.error_description, params.error, params.error_uri));
+          }
           if (!accessToken) { return self.error(new Error('Failed to obtain access token')); }
 
           self._loadUserProfile(accessToken, function(err, profile) {

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -1176,7 +1176,7 @@ describe('OAuth2Strategy', function() {
       });
     }); // that errors due to token request error, in node-oauth object literal form with OAuth 2.0-compatible body
 
-    describe('that does not error but has result body with error due to token request error, in node-oauth object literal form with OAuth 2.0-compatible body', function() {
+    describe('that does not error but has result body with error due to token request error, in parsed node-oauth object form with OAuth 2.0-compatible body', function() {
       var strategy = new OAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',
         tokenURL: 'https://www.example.com/oauth2/token',


### PR DESCRIPTION
The OAuth2 spec states [the authorization server should respond with a HTTP 400](https://tools.ietf.org/html/rfc6749#section-5.2) if there is an error in the access token response. The details of the error are conveyed in the error, error_description, and error_uri fields in the response.

GitHub OAuth does not follow this spec exactly and can return an error response ([examples](https://developer.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors/)) with HTTP code 200. In this case, the error from GitHub is swallowed and instead we return [a generic error](https://github.com/jaredhanson/passport-oauth2/blob/5fcd4c5238a3785794c8c8d0b4a1ab94f1f67bc1/lib/strategy.js#L178). This makes it difficult to debug exactly what went wrong when GitHub returns an access token response error.