### PR TITLE
Prevent Null Point Error on null req.connection

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ exports.originalURL = function(req, options) {
   var trustProxy = options.proxy;
   
   var proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
-    , tls = req.connection.encrypted || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0])
+    , tls = (req.connection && req.connection.encrypted) || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0])
     , host = (trustProxy && req.headers['x-forwarded-host']) || req.headers.host
     , protocol = tls ? 'https' : 'http'
     , path = req.url || '';


### PR DESCRIPTION
`req.connection`, an alias of `req.socket` can be null, causing a null pointer exception when reconstructing a request URL.

See https://github.com/jaredhanson/passport-oauth2/issues/183